### PR TITLE
imp/fetch-echo: Add logging for fetch operation

### DIFF
--- a/release-preflight.sh
+++ b/release-preflight.sh
@@ -3,6 +3,7 @@ IFS=$'\n'
 TMP_FILE=/tmp/release-$(date +"%T").log
 
 # Update local origin
+echo "Fetching latest from origin..."
 git fetch -q
 
 # Write comparison of master and develop to temp file


### PR DESCRIPTION
Adding some logging when the `git fetch` operation is happening so the user knows why the terminal is hanging.