### PR TITLE
fix/log-ref-parsing: Improve ref id parsing

### DIFF
--- a/release-preflight.sh
+++ b/release-preflight.sh
@@ -50,11 +50,11 @@ while read -r commit ; do
   if echo $commit | grep -q "release/*"; then
     continue
   elif echo $commit | grep -qE "^[^:]*$"; then 
-    OTHER=("${OTHER[@]}" "$(echo $commit | cut -c 10-)")
+    OTHER=("${OTHER[@]}" "$(echo $commit | cut -d " " -f 2 )")
   elif echo $commit | grep -qE "[A-Za-z]{3,11}\/[A-Za-z]{2,4}-[0-9]{1,5}"; then
-    CONVENTIONAL=("${CONVENTIONAL[@]}" "$(echo $commit | cut -c 10- | cut -d ':' -f 1)")
+    CONVENTIONAL=("${CONVENTIONAL[@]}" "$(echo $commit | cut -d " " -f 2 | cut -d ':' -f 1)")
   else
-    OTHER=("${OTHER[@]}" "$(echo $commit | cut -c 10- | cut -d ':' -f 1)")
+    OTHER=("${OTHER[@]}" "$(echo $commit | cut -d " " -f 2 | cut -d ':' -f 1)")
   fi
 done < $TMP_FILE
 


### PR DESCRIPTION
Turns out you can't rely on the length of the commit Id being the same. Now cutting at the space to address that.

What the output I'm processing looks like, for reference:
```
1a20348 fix/AD-1337: more change
```