### PR TITLE
imp/log-formatting: Use --pretty=format to remove commit hash, simpli…

### DIFF
--- a/release-preflight.sh
+++ b/release-preflight.sh
@@ -7,7 +7,7 @@ echo "Fetching latest from origin..."
 git fetch -q
 
 # Write comparison of master and develop to temp file
-git log origin/master..origin/develop --oneline --no-merges --no-decorate > $TMP_FILE
+git log origin/master..origin/develop --oneline --no-merges --pretty=format:"%s" > $TMP_FILE
 
 # Read in domain name if it's not provided in env
 if [[ -z $JIRA_DOMAIN ]]; then
@@ -50,11 +50,11 @@ while read -r commit ; do
   if echo $commit | grep -q "release/*"; then
     continue
   elif echo $commit | grep -qE "^[^:]*$"; then 
-    OTHER=("${OTHER[@]}" "$(echo $commit | cut -d " " -f 2 )")
+    OTHER=("${OTHER[@]}" "$commit")
   elif echo $commit | grep -qE "[A-Za-z]{3,11}\/[A-Za-z]{2,4}-[0-9]{1,5}"; then
-    CONVENTIONAL=("${CONVENTIONAL[@]}" "$(echo $commit | cut -d " " -f 2 | cut -d ':' -f 1)")
+    CONVENTIONAL=("${CONVENTIONAL[@]}" "$(echo $commit | cut -d ':' -f 1)")
   else
-    OTHER=("${OTHER[@]}" "$(echo $commit | cut -d " " -f 2 | cut -d ':' -f 1)")
+    OTHER=("${OTHER[@]}" "$(echo $commit | cut -d ':' -f 2 | tail -c 1)")
   fi
 done < $TMP_FILE
 


### PR DESCRIPTION
Remove the `cut` usage in favor of a better formatted git log coming in